### PR TITLE
METRICS: set IoU absent score to 1.0 to avoid unjust IoU penalization 

### DIFF
--- a/semantic_val/models/model.py
+++ b/semantic_val/models/model.py
@@ -99,9 +99,9 @@ class SegmentationModel(LightningModule):
             # TODO: gamma should be a parameter ?
             self.criterion = WeightedFocalLoss(weights=weights, gamma=2.0)
 
-        self.train_iou = IoU(n_classes, reduction="none")
-        self.val_iou = IoU(n_classes, reduction="none")
-        self.test_iou = IoU(n_classes, reduction="none")
+        self.train_iou = IoU(n_classes, reduction="none", absent_score=1.0)
+        self.val_iou = IoU(n_classes, reduction="none", absent_score=1.0)
+        self.test_iou = IoU(n_classes, reduction="none", absent_score=1.0)
         self.train_accuracy = Accuracy()
         self.val_accuracy = Accuracy()
         self.test_accuracy = Accuracy()


### PR DESCRIPTION
cf. https://github.com/PyTorchLightning/pytorch-lightning/issues/3097#issue-683868974 in particular